### PR TITLE
Add windows2012R2 stack to buildpack_test_runner

### DIFF
--- a/lib/machete/buildpack_test_runner.rb
+++ b/lib/machete/buildpack_test_runner.rb
@@ -123,10 +123,10 @@ USAGE
     end
 
     def validate_stack_option
-      if @stack != "cflinuxfs2"
+      if !["cflinuxfs2", "windows2012R2"].include?(@stack)
         arg_error = <<-ERROR
   ERROR: Invalid argument passed in for --stack option.
-  The valid --stack options are [ 'cflinuxfs2' ]
+  The valid --stack options are [ 'cflinuxfs2', 'windows2012R2' ]
 ERROR
         raise ArgumentError.new(arg_error)
       end


### PR DESCRIPTION
Hey Buildpacks Team,

This PR allows buildpack specs to be run against the windows2012R2 stack.